### PR TITLE
feat(docs): build off vulcan blog post for example container update

### DIFF
--- a/Documentation/example-container-update.md
+++ b/Documentation/example-container-update.md
@@ -2,7 +2,9 @@
 
 Getting a distributed application running across a CoreOS cluster is [easy with fleet]({{site.url}}/docs/launching-containers/launching/fleet-example-deployment/). The hard part is deploying an update to the containers that make up the system, without having any downtime. The update service provides the tools we need to make this happen in a graceful and transparent way.
 
-To orchestrate the update, we need to run a "sidekick" for each of the app containers, which will check for an update and run a few [fleetctl]({{site.url}}/docs/launching-containers/launching/fleet-using-the-client/) commands if there is a new version. It's important to note that the updater used in this example is extremely simple and shouldn't be used for any production system.
+This orchestration happens through an updater which is responsible for reporting the progress of the update ([via the Omaha protocol](https://github.com/coreos-inc/updatectl/blob/master/Documentation/protocol.md)) and executing the commands that actually verify and apply the update. Each application can have their own updater to execute app-specific commands or you can share the same update logic across the applications that you run. This guide will implement an extremly simple updater that uses the `updatectl watch` command to be notified of an update. It's important to note that using this scheme shouldn't be used for any production system. 
+
+To orchestrate the update, we need to run a "sidekick" for each of the app containers, which will check for an update and run a few [fleetctl]({{site.url}}/docs/launching-containers/launching/fleet-using-the-client/) commands if there is a new version.
 
 We're going to build off the example described in the [Zero Downtime Frontend Deploys with Vulcand]() blog post. This guide is going to assume your application is able to function with mixed versions running. Before continuing, follow the directions in the blog post for scenario 1, a rolling frontend update. Check that vulcan is serving traffic correctly but stop when you reach the "Start Version 2.0.0" step. Instead of launching those manually, we're going to automatically update them.
 


### PR DESCRIPTION
Remove a bunch of duplication but building off the vulcan blog post.
