### PR TITLE
chore(bump-version): add bump-version script

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -43,7 +43,7 @@ func main() {
 	app.Name = "updatectl"
 	app.Usage = "updatectl is a command line driven interface to the roller."
 	app.Action = handle(listGroups)
-	app.Version = version.SemVersion.String()
+	app.Version = version.Version
 	app.Flags = []cli.Flag{
 		cli.StringFlag{"server, s", "http://localhost:8000", "Update server to connect to"},
 		cli.BoolFlag{"debug, D", "Output debugging info to stderr"},

--- a/scripts/bump-version
+++ b/scripts/bump-version
@@ -1,0 +1,34 @@
+#!/bin/sh -e
+
+function usage {
+    echo "usage: $0 <version>"
+    exit 1
+}
+
+VER=$1
+
+if [ -z $VER ]; then
+    usage
+fi
+
+BASEDIR=$(dirname $0)/..
+cd $BASEDIR
+
+VERSION_FILE=version/version.go
+
+# edit version.go
+cat <<EOF > $VERSION_FILE
+package version
+
+const Version = "${VER}"
+EOF
+
+# Commit changes to version.go
+git add version/version.go
+git commit -m "chore(version): ${VER}"
+
+# Tag the latest commit with the verison number.
+git tag v${VER} --sign -m "v${VER}"
+echo "New version tagged at v$VER. Pushing to coreos-inc/updatectl."
+
+git push git@github.com:coreos-inc/updatectl v${VER}

--- a/version/version.go
+++ b/version/version.go
@@ -1,17 +1,3 @@
 package version
 
-import (
-	"github.com/coreos/go-semver/semver"
-)
-
-const Version = "0.1.0+git"
-
-var SemVersion semver.Version
-
-func init() {
-	sv, err := semver.NewVersion(Version)
-	if err != nil {
-		panic("bad version string!")
-	}
-	SemVersion = *sv
-}
+const Version = "v0.1.2"


### PR DESCRIPTION
@phillips I broke the version tagging script out to this PR for discussion. @sym3tri was interested in it getting the version from `--version`, committing changes to `version.go`, and tagging the version in Git. Was this what you had in mind?
