### PR TITLE
refactor(*): remove codegangsta/cli and replace with custom Command

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -3,40 +3,33 @@ package main
 import (
 	"fmt"
 	"log"
-	"os"
 	"text/tabwriter"
 
 	"github.com/coreos-inc/updatectl/client/update/v1"
-	"github.com/codegangsta/cli"
 )
 
-func ChannelCommands() []cli.Command {
-	return []cli.Command{
-		{
-			Name:        "list-channels",
-			Usage:       "list-channels <appId>",
-			Description: `List all channels for an application.`,
-			Action:      handle(listChannels),
-		},
-		{
-			Name:        "update-channel",
-			Usage:       "update-channel <appId> <channel> <version>",
-			Description: `Update a given channel given a group, app, channel and version.`,
-			Action:      handle(updateChannel),
-		},
+var (
+	cmdListChannels = &Command{
+		Name:        "list-channels",
+		Usage:       "<appId>",
+		Description: `List all channels for an application.`,
+		Run:         listChannels,
 	}
-}
+	cmdUpdateChannel = &Command{
+		Name:        "update-channel",
+		Usage:       "<appId> <channel> <version>",
+		Description: `Update a given channel given a group, app, channel and version.`,
+		Run:         updateChannel,
+	}
+)
 
 func formatChannel(channel *update.AppChannel) string {
 	return fmt.Sprintf("%s\t%s\n", channel.Label, channel.Version)
 }
 
-func listChannels(c *cli.Context, service *update.Service, out *tabwriter.Writer) {
-	args := c.Args()
-
+func listChannels(args []string, service *update.Service, out *tabwriter.Writer) int {
 	if len(args) != 1 {
-		cli.ShowCommandHelp(c, "list-channels")
-		os.Exit(1)
+		return ERROR_USAGE
 	}
 
 	listCall := service.Channel.List(args[0])
@@ -49,15 +42,12 @@ func listChannels(c *cli.Context, service *update.Service, out *tabwriter.Writer
 		fmt.Fprintf(out, "%s", formatChannel(channel))
 	}
 	out.Flush()
+	return OK
 }
 
-
-func updateChannel(c *cli.Context, service *update.Service, out *tabwriter.Writer) {
-	args := c.Args()
-
+func updateChannel(args []string, service *update.Service, out *tabwriter.Writer) int {
 	if len(args) != 3 {
-		fmt.Println("usage: <appid> <channel> <version>")
-		os.Exit(1)
+		return ERROR_USAGE
 	}
 
 	channelReq := &update.ChannelRequest{Version: args[2]}
@@ -70,4 +60,5 @@ func updateChannel(c *cli.Context, service *update.Service, out *tabwriter.Write
 
 	fmt.Fprintf(out, "%s\n", channel.Version)
 	out.Flush()
+	return OK
 }

--- a/cmd.go
+++ b/cmd.go
@@ -1,63 +1,179 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"text/tabwriter"
 
 	"github.com/coreos-inc/updatectl/auth"
-	"github.com/coreos-inc/updatectl/version"
 	"github.com/coreos-inc/updatectl/client/update/v1"
-	"github.com/codegangsta/cli"
+	"github.com/coreos-inc/updatectl/version"
 )
 
-type handlerFunc func(*cli.Context, *update.Service, *tabwriter.Writer)
+const (
+	cliName        = "updatectl"
+	cliDescription = "updatectl is a command line driven interface to the roller."
 
-func getHawkClient(c *cli.Context) *http.Client {
-	return &http.Client{Transport: &auth.HawkRoundTripper{
-		c.GlobalString("user"),
-		c.GlobalString("key"),
-	}}
+	OK = iota
+	// Error Codes
+	ERROR_API
+	ERROR_USAGE
+	ERROR_NO_COMMAND
+)
+
+type Command struct {
+	Name        string       // Name of the Command and the string to use to invoke it
+	Summary     string       // One-sentence summary of what the Command does
+	Usage       string       // Usage options/arguments
+	Description string       // Detailed description of command
+	Flags       flag.FlagSet // Set of flags associated with this command
+	Run         handlerFunc  // Run a command with the given arguments
 }
 
-func handle(fn handlerFunc) func(c *cli.Context) {
-	out := new(tabwriter.Writer)
+var (
+	out           *tabwriter.Writer
+	globalFlagSet *flag.FlagSet
+	commands      []*Command
+
+	globalFlags struct {
+		Server  string
+		User    string
+		Key     string
+		Debug   bool
+		Version bool
+	}
+)
+
+func init() {
+	out = new(tabwriter.Writer)
 	out.Init(os.Stdout, 0, 8, 1, '\t', 0)
 
-	return func(c *cli.Context) {
-		client := getHawkClient(c)
+	globalFlagSet = flag.NewFlagSet(cliName, flag.ExitOnError)
+	globalFlagSet.StringVar(&globalFlags.Server, "server", "http://localhost:8000", "Update server to connect to")
+	globalFlagSet.BoolVar(&globalFlags.Debug, "debug", false, "Output debugging info to stderr")
+	globalFlagSet.BoolVar(&globalFlags.Version, "version", false, "Print version information")
+	globalFlagSet.StringVar(&globalFlags.User, "user", os.Getenv("UPDATECTL_USER"), "API Username")
+	globalFlagSet.StringVar(&globalFlags.Key, "key", os.Getenv("UPDATECTL_KEY"), "API Key")
+
+	commands = []*Command{
+		// admin.go
+		cmdAdminInit,
+		cmdAdminCreateUser,
+		cmdAdminDeleteUser,
+		cmdAdminListUsers,
+		// app.go
+		cmdListApps,
+		cmdCreateApp,
+		cmdUpdateApp,
+		cmdDeleteApp,
+		// channel.go
+		cmdListChannels,
+		cmdUpdateChannel,
+		// client_update.go
+		cmdListClientUpdates,
+		cmdListAppVersions,
+		// fakeclients.go
+		cmdFakeClients,
+		// group.go
+		cmdListGroups,
+		cmdNewGroup,
+		cmdDeleteGroup,
+		cmdUpdateGroup,
+		cmdPauseGroup,
+		cmdUnpauseGroup,
+		cmdRollupGroupVersions,
+		cmdRollupGroupEvents,
+		// help.go
+		cmdHelp,
+		// pkg.go
+		cmdListPackages,
+		cmdNewPackage,
+		// watch.go
+		cmdWatch,
+	}
+}
+
+type handlerFunc func([]string, *update.Service, *tabwriter.Writer) int
+
+func getHawkClient(user string, key string) *http.Client {
+	return &http.Client{Transport: &auth.HawkRoundTripper{user, key}}
+}
+
+func handle(fn handlerFunc) func(f *flag.FlagSet) int {
+	return func(f *flag.FlagSet) (exit int) {
+		user := globalFlags.User
+		key := globalFlags.Key
+		client := getHawkClient(user, key)
 
 		service, err := update.New(client)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		service.BasePath = c.GlobalString("server") + "/_ah/api/update/v1/"
-		fn(c, service, out)
+		service.BasePath = globalFlags.Server + "/_ah/api/update/v1/"
+		exit = fn(f.Args(), service, out)
+		return
 	}
 }
 
+func printVersion(out *tabwriter.Writer) {
+	fmt.Fprintf(out, "%s version %s\n", cliName, version.Version)
+	out.Flush()
+}
+
+func getAllFlags() (flags []*flag.Flag) {
+	return getFlags(globalFlagSet)
+}
+
+func getFlags(flagset *flag.FlagSet) (flags []*flag.Flag) {
+	flags = make([]*flag.Flag, 0)
+	flagset.VisitAll(func(f *flag.Flag) {
+		flags = append(flags, f)
+	})
+	return
+}
+
 func main() {
-	app := cli.NewApp()
-	app.Name = "updatectl"
-	app.Usage = "updatectl is a command line driven interface to the roller."
-	app.Action = handle(listGroups)
-	app.Version = version.Version
-	app.Flags = []cli.Flag{
-		cli.StringFlag{"server, s", "http://localhost:8000", "Update server to connect to"},
-		cli.BoolFlag{"debug, D", "Output debugging info to stderr"},
-		cli.StringFlag{"user, u", os.Getenv("UPDATECTL_USER"), "API Username"},
-		cli.StringFlag{"key, k", os.Getenv("UPDATECTL_KEY"), "API Key"},
+	globalFlagSet.Parse(os.Args[1:])
+	var args = globalFlagSet.Args()
+
+	if globalFlags.Version {
+		printVersion(out)
+		os.Exit(OK)
 	}
 
-	app.Commands = append(app.Commands, GroupCommands()...)
-	app.Commands = append(app.Commands, AppCommands()...)
-	app.Commands = append(app.Commands, ChannelCommands()...)
-	app.Commands = append(app.Commands, PackageCommands()...)
-	app.Commands = append(app.Commands, WatchCommands()...)
-	app.Commands = append(app.Commands, AdminCommands()...)
-	app.Commands = append(app.Commands, ClientUpdateCommands()...)
-	app.Commands = append(app.Commands, FakeClientsCommand()...)
-	app.Run(os.Args)
+	// no command specified - trigger help
+	if len(args) < 1 {
+		args = append(args, "help")
+	}
+
+	var cmd *Command
+
+	// determine which Command should be run
+	for _, c := range commands {
+		if c.Name == args[0] {
+			cmd = c
+			if err := c.Flags.Parse(args[1:]); err != nil {
+				fmt.Println(err.Error())
+				os.Exit(ERROR_USAGE)
+			}
+			break
+		}
+	}
+
+	if cmd == nil {
+		fmt.Printf("%v: unknown subcommand: %q\n", cliName, args[0])
+		fmt.Printf("Run '%v help' for usage.\n", cliName)
+		os.Exit(ERROR_NO_COMMAND)
+	}
+
+	exit := handle(cmd.Run)(&cmd.Flags)
+
+	if exit == ERROR_USAGE {
+		printCommandUsage(cmd)
+	}
+	os.Exit(exit)
 }

--- a/help.go
+++ b/help.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/coreos-inc/updatectl/client/update/v1"
+	"github.com/coreos-inc/updatectl/version"
+)
+
+var (
+	cmdHelp = &Command{
+		Name:        "help",
+		Summary:     "Show a list of commands or help for one command",
+		Usage:       "[COMMAND]",
+		Description: "Show a list of commands or detailed help for one command",
+		Run:         runHelp,
+	}
+
+	globalUsageTemplate  *template.Template
+	commandUsageTemplate *template.Template
+	templFuncs           = template.FuncMap{
+		"descToLines": func(s string) []string {
+			// trim leading/trailing whitespace and split into slice of lines
+			return strings.Split(strings.Trim(s, "\n\t "), "\n")
+		},
+		"printOption": func(name, defvalue, usage string) string {
+			prefix := "--"
+			if len(name) == 1 {
+				prefix = "-"
+			}
+			return fmt.Sprintf("\t%s%s=%s\t%s", prefix, name, defvalue, usage)
+		},
+	}
+)
+
+func init() {
+	globalUsageTemplate = template.Must(template.New("global_usage").Funcs(templFuncs).Parse(`
+NAME:
+{{printf "\t%s - %s" .Executable .Description}}
+
+USAGE:
+{{printf "\t%s" .Executable}} [global options] <command> [command options] [arguments...]
+
+VERSION:
+{{printf "\t%s" .Version}}
+
+COMMANDS:{{range .Commands}}
+{{printf "\t%s\t%s" .Name .Summary}}{{end}}
+
+GLOBAL OPTIONS:{{range .Flags}}
+{{printOption .Name .DefValue .Usage}}{{end}}
+
+Run "{{.Executable}} help <command>" for more details on a specific command.
+`[1:]))
+	commandUsageTemplate = template.Must(template.New("command_usage").Funcs(templFuncs).Parse(`
+NAME:
+{{printf "\t%s - %s" .Cmd.Name .Cmd.Summary}}
+
+USAGE:
+{{printf "\t%s %s %s" .Executable .Cmd.Name .Cmd.Usage}}
+
+DESCRIPTION:
+{{range $line := descToLines .Cmd.Description}}{{printf "\t%s" $line}}
+{{end}}
+{{if .CmdFlags}}OPTIONS:{{range .CmdFlags}}
+{{printOption .Name .DefValue .Usage}}{{end}}
+
+{{end}}For help on global options run "{{.Executable}} help"
+`[1:]))
+}
+
+func runHelp(args []string, service *update.Service, out *tabwriter.Writer) int {
+	if len(args) < 1 {
+		printGlobalUsage()
+		return OK
+	}
+
+	var cmd *Command
+
+	for _, c := range commands {
+		if c.Name == args[0] {
+			cmd = c
+			break
+		}
+	}
+
+	if cmd == nil {
+		fmt.Println("Unrecognized command:", args[0])
+		return ERROR_NO_COMMAND
+	}
+
+	printCommandUsage(cmd)
+	return OK
+}
+
+func printGlobalUsage() {
+	globalUsageTemplate.Execute(out, struct {
+		Executable  string
+		Commands    []*Command
+		Flags       []*flag.Flag
+		Description string
+		Version     string
+	}{
+		cliName,
+		commands,
+		getAllFlags(),
+		cliDescription,
+		version.Version,
+	})
+}
+
+func printCommandUsage(cmd *Command) {
+	commandUsageTemplate.Execute(out, struct {
+		Executable string
+		Cmd        *Command
+		CmdFlags   []*flag.Flag
+	}{
+		cliName,
+		cmd,
+		getFlags(&cmd.Flags),
+	})
+}


### PR DESCRIPTION
I ripped out codegangsta/cli and added a Command structure similar to fleetctl and locksmithctl. In the process a number of things changed in updatectl:
- Handler functions now return an int representing the exit code of the program. Returning ERROR_USAGE prints out the usage information for the command.
- Short flags were removed. We can add them back in if needed.
- Using Go's `flag` module means that there is no difference between a flag that was not passed and a flag that has the default value. Therefore, when checking flag values, try to use some sort of sentinel value that makes sense (-1 for integers, perhaps).

Fixes #11.
