### PR TITLE
fix(watch): don't export UPDATE_SERVICE_URL if there is no update

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -96,14 +96,16 @@ func prepareEnvironment(appID string, version string, oldVersion string, updateC
 	}
 	env = append(env, "UPDATE_SERVICE_APP_ID="+appID)
 
-	url, err := url.Parse(updateCheck.Urls.Urls[0].CodeBase)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
-		os.Exit(1)
-	}
+	if updateCheck.Status == "ok" {
+		url, err := url.Parse(updateCheck.Urls.Urls[0].CodeBase)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, err.Error())
+			os.Exit(1)
+		}
 
-	url.Path = path.Join(url.Path, updateCheck.Manifest.Packages.Packages[0].Name)
-	env = append(env, "UPDATE_SERVICE_URL="+url.String())
+		url.Path = path.Join(url.Path, updateCheck.Manifest.Packages.Packages[0].Name)
+		env = append(env, "UPDATE_SERVICE_URL="+url.String())
+	}
 	return env
 }
 


### PR DESCRIPTION
If updates on the channel were paused then watch would try to deference a nil pointer and panic.
