### PR TITLE
fix: Clarifying configuration of pre-requisites a round

### DIFF
--- a/Documentation/configure-machines.md
+++ b/Documentation/configure-machines.md
@@ -1,6 +1,9 @@
 # Configure Machines to Use CoreUpdate
 
-Configuring new or existing CoreOS machines to communicate with a [CoreUpdate](https://coreos.com/products/coreupdate) instance is a simple change to a configuration file.
+Configuring new or existing CoreOS machines to communicate with a [CoreUpdate](https://coreos.com/products/coreupdate) instance is a simple change to a configuration file.  Prior to making these changes ensure that you have the following information:
+
+  - The server endpoint (in this example we will use `customer.update.core-os.net` as our example hostname)
+  - The group identifier you wish to use. By default, the identifier for a group of machines is a UUID generated when the group was created. You may optionally specify a unique string which contains the characters `a-Z`, `0-9`, `-`, and `_`. This can be seen in practice with the default groups "alpha", "beta", and "stable" that map to those respective channels. The uniqueness of the string need only be in scope of the CoreUpdate deployment, not globally.
 
 ## New Machines
 


### PR DESCRIPTION
A customer noted that the documentation was a bit confusing.  This
attempts to make the requirements around knowing your hostname for
coreupdate and that the group id will be a UUID only in the case of
a custom group more clear.