### PR TITLE
fix: fixing typo in package create

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -91,7 +91,7 @@ var (
 	cmdPackageCreateBulk = &Command{
 		Name:        "package create bulk",
 		Usage:       "[OPTION]...",
-		Description: `Upload package from a folder output by 'package donload'.`,
+		Description: `Upload package from a folder output by 'package download'.`,
 		Run:         packageCreateBulk,
 	}
 	cmdPackageUploadPayload = &Command{


### PR DESCRIPTION
When looking at the package create verb the word "download" is
misspelled.