### PR TITLE
Fix a spelling mistake for group command

### DIFF
--- a/group.go
+++ b/group.go
@@ -24,7 +24,7 @@ var (
 
 	cmdGroup = &Command{
 		Name:    "group",
-		Summary: "Operations that manage groups in an applciation.",
+		Summary: "Operations that manage groups in an application.",
 		Subcommands: []*Command{
 			cmdGroupList,
 			cmdGroupCreate,


### PR DESCRIPTION
Just noticed a little spelling mistake in the command output.