### PR TITLE
guard initial watch run

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -170,7 +170,10 @@ func watch(args []string, service *update.Service, out *tabwriter.Writer) int {
 		fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(1)
 	}
-	runCmd(args[0], args[1:], appId, version, "", updateCheck)
+
+	if updateCheck.Status != "noupdate" && updateCheck.Status == "error-version" {
+		runCmd(args[0], args[1:], appId, version, "", updateCheck)
+	}
 
 	for {
 		select {


### PR DESCRIPTION
Regarding watch, the docs say ``This will exec a program of your choosing every time a new update is available.``

So, this blocks the initial command run unless theres an update. Otherwise there is nothing to do and the expected (and necessary) environment variables are never set.