### PR TITLE
main: fix method of appending filename to baseUrl

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -424,7 +424,14 @@ func createPackageFromInfoFile(filename string, service *update.Service, handleE
 			pkg.AppId, pkg.Version,
 			path.Base(pkg.Url),
 		)
-		pkg.Url = path.Join(baseUrl, filename)
+
+		u, err := url.Parse(baseUrl)
+		if err != nil {
+			handleError(err)
+			return
+		}
+		u.Path = path.Join(u.Path, filename)
+		pkg.Url = u.String()
 	}
 
 	// Add package


### PR DESCRIPTION
Bulk package creation was incorrectly using path.Join() to join parts
of a URL. This strips off extra slashes that URLs require to be valid.
Now builds a url.Url object and uses path.Join to join the path
components only.

Fixes #114