### PR TITLE
instance: use uuid for clientId

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -336,7 +336,7 @@ func instanceFake(args []string, service *update.Service, out *tabwriter.Writer)
 
 	for i := 0; i < instanceFlags.clientsPerApp; i++ {
 		c := &Client{
-			Id:             fmt.Sprintf("{fake-client-%03d}", i),
+			Id:             uuid.New(),
 			SessionId:      uuid.New(),
 			Version:        instanceFlags.version,
 			AppId:          instanceFlags.appId.String(),

--- a/instance.go
+++ b/instance.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -336,7 +337,7 @@ func instanceFake(args []string, service *update.Service, out *tabwriter.Writer)
 
 	for i := 0; i < instanceFlags.clientsPerApp; i++ {
 		c := &Client{
-			Id:             uuid.New(),
+			Id:             strings.Replace(uuid.New(), "-", "", -1),
 			SessionId:      uuid.New(),
 			Version:        instanceFlags.version,
 			AppId:          instanceFlags.appId.String(),


### PR DESCRIPTION
clientIds are all uuids when being generated by update_engine, so the instance faker should adhere to that as well.

Also, CoreUpdate now requires clientIds to be uuids, so this will fail when run against newer versions of CoreUpdate. 