### PR TITLE
group: use new update-percent api

### DIFF
--- a/client/update/v1/update-api.json
+++ b/client/update/v1/update-api.json
@@ -359,16 +359,9 @@
     "oemBlacklist": {
      "type": "string"
     },
-    "updateCount": {
+    "updatePercent": {
      "type": "integer",
-     "format": "int32"
-    },
-    "updateInterval": {
-     "type": "integer",
-     "format": "int32"
-    },
-    "updatePooling": {
-     "type": "boolean"
+     "format": "float64"
     },
     "updatesPaused": {
      "type": "boolean"
@@ -1215,18 +1208,9 @@
        "type": "string",
        "location": "query"
       },
-      "updateCount": {
+      "updatePercent": {
        "type": "integer",
-       "format": "int32",
-       "location": "query"
-      },
-      "updateInterval": {
-       "type": "integer",
-       "format": "int32",
-       "location": "query"
-      },
-      "updatePooling": {
-       "type": "boolean",
+       "format": "float64",
        "location": "query"
       },
       "updatesPaused": {
@@ -1270,18 +1254,9 @@
        "type": "string",
        "location": "query"
       },
-      "updateCount": {
+      "updatePercent": {
        "type": "integer",
-       "format": "int32",
-       "location": "query"
-      },
-      "updateInterval": {
-       "type": "integer",
-       "format": "int32",
-       "location": "query"
-      },
-      "updatePooling": {
-       "type": "boolean",
+       "format": "float64",
        "location": "query"
       },
       "updatesPaused": {

--- a/client/update/v1/update-gen.go
+++ b/client/update/v1/update-gen.go
@@ -9,10 +9,10 @@ package update
 
 import (
 	"bytes"
-	"github.com/coreos/updateservicectl/Godeps/_workspace/src/code.google.com/p/google-api-go-client/googleapi"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/coreos/updateservicectl/Godeps/_workspace/src/code.google.com/p/google-api-go-client/googleapi"
 	"io"
 	"net/http"
 	"net/url"
@@ -351,11 +351,7 @@ type Group struct {
 
 	OemBlacklist string `json:"oemBlacklist,omitempty"`
 
-	UpdateCount int64 `json:"updateCount,omitempty"`
-
-	UpdateInterval int64 `json:"updateInterval,omitempty"`
-
-	UpdatePooling bool `json:"updatePooling,omitempty"`
+	UpdatePercent float64 `json:"updatePercent,omitempty"`
 
 	UpdatesPaused bool `json:"updatesPaused,omitempty"`
 }
@@ -2468,21 +2464,9 @@ func (c *GroupDeleteCall) OemBlacklist(oemBlacklist string) *GroupDeleteCall {
 	return c
 }
 
-// UpdateCount sets the optional parameter "updateCount":
-func (c *GroupDeleteCall) UpdateCount(updateCount int64) *GroupDeleteCall {
-	c.opt_["updateCount"] = updateCount
-	return c
-}
-
-// UpdateInterval sets the optional parameter "updateInterval":
-func (c *GroupDeleteCall) UpdateInterval(updateInterval int64) *GroupDeleteCall {
-	c.opt_["updateInterval"] = updateInterval
-	return c
-}
-
-// UpdatePooling sets the optional parameter "updatePooling":
-func (c *GroupDeleteCall) UpdatePooling(updatePooling bool) *GroupDeleteCall {
-	c.opt_["updatePooling"] = updatePooling
+// UpdatePercent sets the optional parameter "updatePercent":
+func (c *GroupDeleteCall) UpdatePercent(updatePercent float64) *GroupDeleteCall {
+	c.opt_["updatePercent"] = updatePercent
 	return c
 }
 
@@ -2505,14 +2489,8 @@ func (c *GroupDeleteCall) Do() (*Group, error) {
 	if v, ok := c.opt_["oemBlacklist"]; ok {
 		params.Set("oemBlacklist", fmt.Sprintf("%v", v))
 	}
-	if v, ok := c.opt_["updateCount"]; ok {
-		params.Set("updateCount", fmt.Sprintf("%v", v))
-	}
-	if v, ok := c.opt_["updateInterval"]; ok {
-		params.Set("updateInterval", fmt.Sprintf("%v", v))
-	}
-	if v, ok := c.opt_["updatePooling"]; ok {
-		params.Set("updatePooling", fmt.Sprintf("%v", v))
+	if v, ok := c.opt_["updatePercent"]; ok {
+		params.Set("updatePercent", fmt.Sprintf("%v", v))
 	}
 	if v, ok := c.opt_["updatesPaused"]; ok {
 		params.Set("updatesPaused", fmt.Sprintf("%v", v))
@@ -2568,19 +2546,10 @@ func (c *GroupDeleteCall) Do() (*Group, error) {
 	//       "location": "query",
 	//       "type": "string"
 	//     },
-	//     "updateCount": {
-	//       "format": "int32",
+	//     "updatePercent": {
+	//       "format": "float64",
 	//       "location": "query",
 	//       "type": "integer"
-	//     },
-	//     "updateInterval": {
-	//       "format": "int32",
-	//       "location": "query",
-	//       "type": "integer"
-	//     },
-	//     "updatePooling": {
-	//       "location": "query",
-	//       "type": "boolean"
 	//     },
 	//     "updatesPaused": {
 	//       "location": "query",
@@ -2630,21 +2599,9 @@ func (c *GroupGetCall) OemBlacklist(oemBlacklist string) *GroupGetCall {
 	return c
 }
 
-// UpdateCount sets the optional parameter "updateCount":
-func (c *GroupGetCall) UpdateCount(updateCount int64) *GroupGetCall {
-	c.opt_["updateCount"] = updateCount
-	return c
-}
-
-// UpdateInterval sets the optional parameter "updateInterval":
-func (c *GroupGetCall) UpdateInterval(updateInterval int64) *GroupGetCall {
-	c.opt_["updateInterval"] = updateInterval
-	return c
-}
-
-// UpdatePooling sets the optional parameter "updatePooling":
-func (c *GroupGetCall) UpdatePooling(updatePooling bool) *GroupGetCall {
-	c.opt_["updatePooling"] = updatePooling
+// UpdatePercent sets the optional parameter "updatePercent":
+func (c *GroupGetCall) UpdatePercent(updatePercent float64) *GroupGetCall {
+	c.opt_["updatePercent"] = updatePercent
 	return c
 }
 
@@ -2667,14 +2624,8 @@ func (c *GroupGetCall) Do() (*Group, error) {
 	if v, ok := c.opt_["oemBlacklist"]; ok {
 		params.Set("oemBlacklist", fmt.Sprintf("%v", v))
 	}
-	if v, ok := c.opt_["updateCount"]; ok {
-		params.Set("updateCount", fmt.Sprintf("%v", v))
-	}
-	if v, ok := c.opt_["updateInterval"]; ok {
-		params.Set("updateInterval", fmt.Sprintf("%v", v))
-	}
-	if v, ok := c.opt_["updatePooling"]; ok {
-		params.Set("updatePooling", fmt.Sprintf("%v", v))
+	if v, ok := c.opt_["updatePercent"]; ok {
+		params.Set("updatePercent", fmt.Sprintf("%v", v))
 	}
 	if v, ok := c.opt_["updatesPaused"]; ok {
 		params.Set("updatesPaused", fmt.Sprintf("%v", v))
@@ -2730,19 +2681,10 @@ func (c *GroupGetCall) Do() (*Group, error) {
 	//       "location": "query",
 	//       "type": "string"
 	//     },
-	//     "updateCount": {
-	//       "format": "int32",
+	//     "updatePercent": {
+	//       "format": "float64",
 	//       "location": "query",
 	//       "type": "integer"
-	//     },
-	//     "updateInterval": {
-	//       "format": "int32",
-	//       "location": "query",
-	//       "type": "integer"
-	//     },
-	//     "updatePooling": {
-	//       "location": "query",
-	//       "type": "boolean"
 	//     },
 	//     "updatesPaused": {
 	//       "location": "query",

--- a/group.go
+++ b/group.go
@@ -11,16 +11,15 @@ import (
 
 var (
 	groupFlags struct {
-		label          StringFlag
-		channel        StringFlag
-		appId          StringFlag
-		groupId        StringFlag
-		oemBlacklist   StringFlag
-		start          int64
-		end            int64
-		resolution     int64
-		updateCount    int64
-		updateInterval int64
+		label         StringFlag
+		channel       StringFlag
+		appId         StringFlag
+		groupId       StringFlag
+		oemBlacklist  StringFlag
+		start         int64
+		end           int64
+		resolution    int64
+		updatePercent float64
 	}
 
 	cmdGroup = &Command{
@@ -116,10 +115,8 @@ func init() {
 		"Channel to associate with the group.")
 	cmdGroupUpdate.Flags.Var(&groupFlags.oemBlacklist, "oem-blacklist",
 		"Comma-separated list of OEMs to exclude from updates.")
-	cmdGroupUpdate.Flags.Int64Var(&groupFlags.updateCount, "update-count",
-		-1, "Number of instances per interval")
-	cmdGroupUpdate.Flags.Int64Var(&groupFlags.updateInterval,
-		"update-interval", -1, "Interval between updates")
+	cmdGroupUpdate.Flags.Float64Var(&groupFlags.updatePercent,
+		"update-percent", -1, "Percentage of machines to update")
 
 	cmdGroupPause.Flags.Var(&groupFlags.appId, "app-id",
 		"Application containing the group to pause.")
@@ -154,13 +151,13 @@ func init() {
 		"End date filter")
 }
 
-const groupHeader = "Label\tApp\tChannel\tId\tPaused\tCount\tInterval\n"
+const groupHeader = "Label\tApp\tChannel\tId\tPaused\tPercent\n"
 
 func formatGroup(group *update.Group) string {
-	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%v\t%v\n",
+	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%v\n",
 		group.Label, group.AppId, group.ChannelId,
 		group.Id, strconv.FormatBool(group.UpdatesPaused),
-		group.UpdateCount, group.UpdateInterval)
+		group.UpdatePercent)
 }
 
 func groupList(args []string, service *update.Service, out *tabwriter.Writer) int {
@@ -337,14 +334,8 @@ func groupUpdate(args []string, service *update.Service, out *tabwriter.Writer) 
 		log.Fatal(err)
 	}
 
-	checkUpdatePooling := false
-	if groupFlags.updateCount != -1 {
-		group.UpdateCount = groupFlags.updateCount
-		checkUpdatePooling = true
-	}
-	if groupFlags.updateInterval != -1 {
-		group.UpdateInterval = groupFlags.updateInterval
-		checkUpdatePooling = true
+	if groupFlags.updatePercent != -1 {
+		group.UpdatePercent = groupFlags.updatePercent
 	}
 	if groupFlags.label.Get() != nil {
 		group.Label = groupFlags.label.String()
@@ -354,16 +345,6 @@ func groupUpdate(args []string, service *update.Service, out *tabwriter.Writer) 
 	}
 	if groupFlags.oemBlacklist.Get() != nil {
 		group.OemBlacklist = groupFlags.oemBlacklist.String()
-	}
-
-	// set update pooling based on other flags
-	// this only changes if the user changed a value
-	if checkUpdatePooling {
-		if group.UpdateCount == 0 && group.UpdateInterval == 0 {
-			group.UpdatePooling = false
-		} else {
-			group.UpdatePooling = true
-		}
 	}
 
 	updateCall := service.Group.Patch(groupFlags.appId.String(), groupFlags.groupId.String(), group)

--- a/group.go
+++ b/group.go
@@ -354,7 +354,7 @@ func groupUpdate(args []string, service *update.Service, out *tabwriter.Writer) 
 		log.Fatal(err)
 	}
 
-	fmt.Fprintln(out, groupHeader)
+	fmt.Fprint(out, groupHeader)
 	fmt.Fprintf(out, "%s", formatGroup(group))
 
 	out.Flush()


### PR DESCRIPTION
this changes the group update operation to use a percentage of machines to update instead of the old count/interval semantics.