### PR TITLE
release v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 let you manage users, groups, packages and write a very simple client that gets
 its state via environment variables.
 
+## Compatibility with CoreUpdate versions
+
+`updateservicectl v2.0.0` is compatible with `CoreUpdate v2.2.0` or newer.
+
+`updateservicectl v1.4.0` is compatible with `CoreUpdate v2.1.1` or older.
+
 ## About the Update Service
 
 The update service is a tool that helps you manage large-scale rolling upgrades of software. The service consists of three main parts:

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.0.0"
+const Version = "2.0.0+git"

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "1.4.0+git"
+const Version = "2.0.0"


### PR DESCRIPTION
Release notes:

* use new percentage-based machine rollout strategy
* fix issue with fake instances using invalid uuids for machine ids

**WARNING**: This version is only compatible with versions of CoreUpdate that are v2.2.0 or newer. If you are using an older version of CoreUpdate, please continue to use `updateservicectl v1.4.0`.