### PR TITLE
rollout subcommand

### DIFF
--- a/client/update/v1/update-api.json
+++ b/client/update/v1/update-api.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "\"hf84vk5HeqXKpApUTgMOcmfTP8c/bT3HQZJtvzIzFsyQWqTOovsN7Gw\"",
+ "etag": "\"hf84vk5HeqXKpApUTgMOcmfTP8c/7tw3GQM9__ChSSf-au9cv5wobG8\"",
  "discoveryVersion": "v1",
  "id": "update:v1",
  "name": "update",
@@ -570,21 +570,6 @@
    "properties": {
     "active": {
      "type": "boolean"
-    },
-    "appId": {
-     "type": "string"
-    },
-    "groupId": {
-     "type": "string"
-    }
-   }
-  },
-  "RolloutSetReq": {
-   "id": "RolloutSetReq",
-   "type": "object",
-   "properties": {
-    "Rollout": {
-     "$ref": "Rollout"
     },
     "appId": {
      "type": "string"
@@ -1686,7 +1671,7 @@
         "groupId"
        ],
        "request": {
-        "$ref": "RolloutSetReq",
+        "$ref": "Rollout",
         "parameterName": "resource"
        },
        "response": {

--- a/client/update/v1/update-gen.go
+++ b/client/update/v1/update-gen.go
@@ -1312,36 +1312,6 @@ func (s *RolloutActive) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
-type RolloutSetReq struct {
-	Rollout *Rollout `json:"Rollout,omitempty"`
-
-	AppId string `json:"appId,omitempty"`
-
-	GroupId string `json:"groupId,omitempty"`
-
-	// ForceSendFields is a list of field names (e.g. "Rollout") to
-	// unconditionally include in API requests. By default, fields with
-	// empty values are omitted from API requests. However, any non-pointer,
-	// non-interface field appearing in ForceSendFields will be sent to the
-	// server regardless of whether the field is empty or not. This may be
-	// used to include empty fields in Patch requests.
-	ForceSendFields []string `json:"-"`
-
-	// NullFields is a list of field names (e.g. "Rollout") to include in
-	// API requests with the JSON null value. By default, fields with empty
-	// values are omitted from API requests. However, any field with an
-	// empty value appearing in NullFields will be sent to the server as
-	// null. It is an error if a field in this list has a non-empty value.
-	// This may be used to include null fields in Patch requests.
-	NullFields []string `json:"-"`
-}
-
-func (s *RolloutSetReq) MarshalJSON() ([]byte, error) {
-	type NoMethod RolloutSetReq
-	raw := NoMethod(*s)
-	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
-}
-
 type Upstream struct {
 	Id string `json:"id,omitempty"`
 
@@ -6599,21 +6569,21 @@ func (c *GroupRolloutGetCall) Do(opts ...googleapi.CallOption) (*Rollout, error)
 // method id "update.group.rollout.set":
 
 type GroupRolloutSetCall struct {
-	s             *Service
-	appId         string
-	groupId       string
-	rolloutsetreq *RolloutSetReq
-	urlParams_    gensupport.URLParams
-	ctx_          context.Context
-	header_       http.Header
+	s          *Service
+	appId      string
+	groupId    string
+	rollout    *Rollout
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+	header_    http.Header
 }
 
 // Set: Set (and start) a new rollout strategy for this group.
-func (r *GroupRolloutService) Set(appId string, groupId string, rolloutsetreq *RolloutSetReq) *GroupRolloutSetCall {
+func (r *GroupRolloutService) Set(appId string, groupId string, rollout *Rollout) *GroupRolloutSetCall {
 	c := &GroupRolloutSetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
 	c.appId = appId
 	c.groupId = groupId
-	c.rolloutsetreq = rolloutsetreq
+	c.rollout = rollout
 	return c
 }
 
@@ -6649,7 +6619,7 @@ func (c *GroupRolloutSetCall) doRequest(alt string) (*http.Response, error) {
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
 	var body io.Reader = nil
-	body, err := googleapi.WithoutDataWrapper.JSONReader(c.rolloutsetreq)
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.rollout)
 	if err != nil {
 		return nil, err
 	}
@@ -6725,7 +6695,7 @@ func (c *GroupRolloutSetCall) Do(opts ...googleapi.CallOption) (*Rollout, error)
 	//   },
 	//   "path": "apps/{appId}/groups/{groupId}/rollout",
 	//   "request": {
-	//     "$ref": "RolloutSetReq",
+	//     "$ref": "Rollout",
 	//     "parameterName": "resource"
 	//   },
 	//   "response": {

--- a/cmd.go
+++ b/cmd.go
@@ -107,6 +107,8 @@ func init() {
 		cmdInstance,
 		// pkg.go
 		cmdPackage,
+		// rollout.go
+		cmdRollout,
 		// watch.go
 		cmdWatch,
 		// upstream.go

--- a/pkg.go
+++ b/pkg.go
@@ -663,7 +663,7 @@ func downloadPackagePayload(pkg *update.Package, saveTo string, bar *pb.Progress
 	}
 	// Verify the hash matches
 	if string(pkgSha1) != string(sha1h.Sum(nil)) {
-		err = fmt.Errorf("SHA1 sums do not match: %s != $s", string(pkgSha1), string(sha1h.Sum(nil)))
+		err = fmt.Errorf("SHA1 sums do not match: %s != %s", string(pkgSha1), string(sha1h.Sum(nil)))
 		handle(err)
 		return
 	}

--- a/rollout.go
+++ b/rollout.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"text/tabwriter"
+
+	"github.com/coreos/updateservicectl/client/update/v1"
+)
+
+var (
+	rolloutFlags struct {
+		appId   StringFlag
+		groupId StringFlag
+		active  bool
+
+		// linear rollouts
+		frameSize int64
+		duration  int64
+	}
+
+	cmdRollout = &Command{
+		Name:    "rollout",
+		Summary: "Operations on automated rollouts for a group.",
+		Subcommands: []*Command{
+			cmdRolloutCreate,
+			cmdRolloutActivate,
+			cmdRolloutDeactivate,
+		},
+		Run: rolloutGet,
+	}
+	cmdRolloutCreate = &Command{
+		Name:    "rollout create",
+		Usage:   "[OPTION]...",
+		Summary: "Create an automated rollout.",
+		Subcommands: []*Command{
+			cmdRolloutLinear,
+		},
+	}
+	cmdRolloutActivate = &Command{
+		Name:    "rollout activate",
+		Usage:   "[OPTION]...",
+		Summary: "Activate a rollout for a group.",
+		Run:     rolloutActivate,
+	}
+	cmdRolloutDeactivate = &Command{
+		Name:    "rollout deactivate",
+		Usage:   "[OPTION]...",
+		Summary: "Deactivate a rollout for a group.",
+		Run:     rolloutDeactivate,
+	}
+
+	// each type of rollout has it's own subcommand different arguments and
+	// behavior, even though they all use the same API endpoint.
+	cmdRolloutLinear = &Command{
+		Name:    "rollout create linear",
+		Usage:   "[OPTION]...",
+		Summary: "Create a linear rollout.",
+		Run:     rolloutLinear,
+	}
+)
+
+func init() {
+	// flags for getting a rollout
+	cmdRollout.Flags.Var(&rolloutFlags.appId, "app-id",
+		"Application containing the group the rollout is associated with.")
+	cmdRollout.Flags.Var(&rolloutFlags.groupId, "group-id",
+		"ID of the group the rollout is associated with.")
+
+	// flags for activating a rollout
+	cmdRolloutActivate.Flags.Var(&rolloutFlags.appId, "app-id",
+		"Application containing the group the rollout is associated with.")
+	cmdRolloutActivate.Flags.Var(&rolloutFlags.groupId, "group-id",
+		"ID of the group the rollout is associated with.")
+
+	// flags for deactivating a rollout
+	cmdRolloutDeactivate.Flags.Var(&rolloutFlags.appId, "app-id",
+		"Application containing the group the rollout is associated with.")
+	cmdRolloutDeactivate.Flags.Var(&rolloutFlags.groupId, "group-id",
+		"ID of the group the rollout is associated with.")
+
+	// creating a linear rollout
+	cmdRolloutLinear.Flags.Var(&rolloutFlags.appId, "app-id",
+		"Application containing the group the rollout is associated with.")
+	cmdRolloutLinear.Flags.Var(&rolloutFlags.groupId, "group-id",
+		"ID of the group the rollout is associated with.")
+	cmdRolloutLinear.Flags.Int64Var(&rolloutFlags.frameSize, "frame-size", 60,
+		"Duration of a rollout step (or frame) in seconds (default 60 seconds)")
+	cmdRolloutLinear.Flags.Int64Var(&rolloutFlags.duration, "duration", 86400,
+		"Total duration for the rollout to go from 0% to 100%, in seconds (default 1 day)")
+}
+
+func displayRollout(out io.Writer, rollout *update.Rollout) {
+	fmt.Fprintf(out, "rollout:\n")
+	for i, frame := range rollout.Rollout {
+		fmt.Fprintf(out, "Frame %d:\tPercent:\t%f\n", i, frame.Percent)
+		fmt.Fprintf(out, "\tDuration:\t%d\n", frame.Duration)
+	}
+}
+
+func rolloutGet(args []string, service *update.Service, out *tabwriter.Writer) int {
+	if rolloutFlags.appId.Get() == nil ||
+		rolloutFlags.groupId.Get() == nil {
+		return ERROR_USAGE
+	}
+
+	call := service.Group.Rollout.Get(
+		rolloutFlags.appId.String(), rolloutFlags.groupId.String())
+
+	rollout, err := call.Do()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	displayRollout(out, rollout)
+	out.Flush()
+
+	return OK
+}
+
+func setActive(service *update.Service, out *tabwriter.Writer, active bool) int {
+	if rolloutFlags.appId.Get() == nil ||
+		rolloutFlags.groupId.Get() == nil {
+		return ERROR_USAGE
+	}
+
+	rolloutActive := &update.RolloutActive{
+		Active: active,
+	}
+
+	setCall := service.Group.Rollout.Active.Set(
+		rolloutFlags.appId.String(), rolloutFlags.groupId.String(), rolloutActive)
+
+	rolloutActive, err := setCall.Do()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if rolloutActive.Active {
+		fmt.Fprintf(out, "rollout activated\n")
+	} else {
+		fmt.Fprintf(out, "rollout deactivated\n")
+	}
+	out.Flush()
+
+	return OK
+}
+
+func rolloutActivate(args []string, service *update.Service, out *tabwriter.Writer) int {
+	return setActive(service, out, true)
+}
+
+func rolloutDeactivate(args []string, service *update.Service, out *tabwriter.Writer) int {
+	return setActive(service, out, false)
+}
+
+func generateLinear(appId, groupId string, frameSize, totalDuration int64) *update.Rollout {
+	var frames []*update.Frame
+	duration := totalDuration
+	stepSize := 100 / math.Ceil(float64(duration)/float64(frameSize))
+	percent := 0.0
+
+	for {
+		// we stop making frames when we are at the end of the rollout
+		if duration <= 0 {
+			break
+		}
+
+		// set our current frame and step size
+		size := frameSize
+		percent += stepSize
+		if size >= duration {
+			// if that's longer than the time we have left, this is the final
+			// frame. use the rest of the duration to set us to 100%
+			size = duration
+		}
+
+		// append our new frame to the end of the frames list
+		frames = append(frames, &update.Frame{
+			Duration: size,
+			Percent:  percent,
+		})
+
+		// subtract our frame from the total duration
+		duration -= size
+	}
+
+	// add one more frame to bring us up to 100%. the server will set this
+	// frame, and the next time it checks, it will exit the rollout, since the
+	// duration is set to 0.
+	frames = append(frames, &update.Frame{
+		Duration: 0,
+		Percent:  100,
+	})
+
+	return &update.Rollout{
+		AppId:   appId,
+		GroupId: groupId,
+		Rollout: frames,
+	}
+}
+
+func rolloutLinear(args []string, service *update.Service, out *tabwriter.Writer) int {
+	if rolloutFlags.appId.Get() == nil ||
+		rolloutFlags.groupId.Get() == nil ||
+		rolloutFlags.frameSize == 0 ||
+		rolloutFlags.duration == 0 {
+		return ERROR_USAGE
+	}
+
+	rollout := generateLinear(rolloutFlags.appId.String(), rolloutFlags.groupId.String(),
+		rolloutFlags.frameSize, rolloutFlags.duration)
+
+	call := service.Group.Rollout.Set(
+		rolloutFlags.appId.String(), rolloutFlags.groupId.String(), rollout)
+
+	rollout, err := call.Do()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Fprintf(out, "rollout set\n")
+	out.Flush()
+
+	return OK
+}

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/coreos/updateservicectl/client/update/v1"
+)
+
+func eq(a, b *update.Rollout) bool {
+	if a.AppId != b.AppId || a.GroupId != b.GroupId {
+		return false
+	}
+	if len(a.Rollout) != len(b.Rollout) {
+		return false
+	}
+	for i, fa := range a.Rollout {
+		fb := b.Rollout[i]
+		if fa.Percent != fb.Percent {
+			return false
+		}
+		if fa.Duration != fb.Duration {
+			return false
+		}
+	}
+	return true
+}
+
+func TestLinearRolloutGeneration(t *testing.T) {
+	appId := "e96281a6-d1af-4bde-9a0a-97b76e56dc57"
+	groupId := "stable"
+	truth := &update.Rollout{
+		AppId:   appId,
+		GroupId: groupId,
+		Rollout: []*update.Frame{
+			&update.Frame{
+				Percent:  10.0,
+				Duration: 10,
+			},
+			&update.Frame{
+				Percent:  20.0,
+				Duration: 10,
+			},
+			&update.Frame{
+				Percent:  30.0,
+				Duration: 10,
+			},
+			&update.Frame{
+				Percent:  40.0,
+				Duration: 10,
+			},
+			&update.Frame{
+				Percent:  50.0,
+				Duration: 10,
+			},
+			&update.Frame{
+				Percent:  60.0,
+				Duration: 10,
+			},
+			&update.Frame{
+				Percent:  70.0,
+				Duration: 10,
+			},
+			&update.Frame{
+				Percent:  80.0,
+				Duration: 10,
+			},
+			&update.Frame{
+				Percent:  90.0,
+				Duration: 10,
+			},
+			&update.Frame{
+				Percent:  100.0,
+				Duration: 10,
+			},
+			// final frame to force 100%
+			&update.Frame{
+				Percent:  100.0,
+				Duration: 0,
+			},
+		},
+	}
+
+	rollout := generateLinear(appId, groupId, 10, 100)
+
+	if !eq(rollout, truth) {
+		// generate nice frame output
+		var e, g bytes.Buffer
+		displayRollout(&e, truth)
+		displayRollout(&g, rollout)
+		t.Error("incorrect rollout generated.\n")
+		t.Errorf("expected:\n%s\n", e.String())
+		t.Errorf("got:\n%s\n", g.String())
+	}
+}


### PR DESCRIPTION
this pr is for the rollout subcommand. it is the command that contains the meat of the client side work required for the new rollout strategies api. 

this command does several things:
* gets the current rollout for a group
* activates/deactivates the automated rollout behavior for a group
* provides a linear rollout generator

this subcommand is the location where rollout strategies will get implemented for general use in the future. in addition to being a useful rollout strategy, the linear rollout command serves as a reference implementation for future rollout strategies. 