### PR TITLE
release v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ its state via environment variables.
 
 ## Compatibility with CoreUpdate versions
 
+`updateservicectl v2.1.0` is compatible with `CoreUpdate v2.3.0` or newer.
+
 `updateservicectl v2.0.0` is compatible with `CoreUpdate v2.2.0` or newer.
 
 `updateservicectl v1.4.0` is compatible with `CoreUpdate v2.1.1` or older.

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.0.0+git"
+const Version = "2.1.0"

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.1.0"
+const Version = "2.1.0+git"


### PR DESCRIPTION
Release notes draft:

**Warning:** This release contains breaking changes and is only compatible with CoreUpdate v2.3.0 or newer. If you are using an older version of CoreUpdate, please refer to the README for the compatibility matrix.

**Breaking Changes:**
* Add a new subcommand, `group percent`, for modifying the update percent.
  * The `--update-percent` flag is removed from the `group update` subcommand, in favor of using the explicit subcommand.

**New Features:**
* Add a new subcommand, `rollout`, for generating and manipulating automated rollout behavior, a new feature in CoreUpdate v2.3.0. This subcommand currently provides support for generating linear rollouts, as well as getting the current rollout and setting the active status of the automated rollout.

**Bug Fixes:**
* Fix a bug where the help output would show two dfferent usages.
  * Help output is now triggered just with the `--help` flag.

**Development changes:**
* Use glide instead of Godeps for dependency management. This required some non-breaking dependency updates.
* Generate new client bindings, to support the new subcommands above.
  * Include documentation for generating client bindings.
* Use a Makefile instead of build scripts.